### PR TITLE
Use eye transform instead of translation in external_vr

### DIFF
--- a/dom/vr/VRServiceTest.cpp
+++ b/dom/vr/VRServiceTest.cpp
@@ -95,10 +95,15 @@ void VRMockDisplay::Create() {
   state.eyeResolution.width = 1836;   // 1080 * 1.7
   state.eyeResolution.height = 2040;  // 1200 * 1.7
 
+  float identity[16] = { 
+      1.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, 1.0f, 0.0f, 0.0f,
+      0.0f, 0.0f, 1.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 1.0f
+  };
+
   for (uint32_t eye = 0; eye < VRDisplayState::NumEyes; ++eye) {
-    state.eyeTranslation[eye].x = 0.0f;
-    state.eyeTranslation[eye].y = 0.0f;
-    state.eyeTranslation[eye].z = 0.0f;
+    memcpy(state.eyeTransform[eye], identity, sizeof(identity));
     state.eyeFOV[eye] = gfx::VRFieldOfView(45.0, 45.0, 45.0, 45.0);
   }
 
@@ -106,25 +111,8 @@ void VRMockDisplay::Create() {
   state.stageSize.width = 1.0f;
   state.stageSize.height = 1.0f;
 
-  state.sittingToStandingTransform[0] = 1.0f;
-  state.sittingToStandingTransform[1] = 0.0f;
-  state.sittingToStandingTransform[2] = 0.0f;
-  state.sittingToStandingTransform[3] = 0.0f;
-
-  state.sittingToStandingTransform[4] = 0.0f;
-  state.sittingToStandingTransform[5] = 1.0f;
-  state.sittingToStandingTransform[6] = 0.0f;
-  state.sittingToStandingTransform[7] = 0.0f;
-
-  state.sittingToStandingTransform[8] = 0.0f;
-  state.sittingToStandingTransform[9] = 0.0f;
-  state.sittingToStandingTransform[10] = 1.0f;
-  state.sittingToStandingTransform[11] = 0.0f;
-
-  state.sittingToStandingTransform[12] = 0.0f;
+  memcpy(state.sittingToStandingTransform, identity, sizeof(identity));
   state.sittingToStandingTransform[13] = 0.75f;
-  state.sittingToStandingTransform[14] = 0.0f;
-  state.sittingToStandingTransform[15] = 1.0f;
 
   VRHMDSensorState& sensorState = SensorState();
   gfx::Quaternion rot;
@@ -221,9 +209,9 @@ void VRMockDisplay::SetEyeOffset(VREye aEye, double aOffsetX, double aOffsetY,
                                      ? gfx::VRDisplayState::Eye_Left
                                      : gfx::VRDisplayState::Eye_Right;
   VRDisplayState& state = DisplayState();
-  state.eyeTranslation[eye].x = (float)aOffsetX;
-  state.eyeTranslation[eye].y = (float)aOffsetY;
-  state.eyeTranslation[eye].z = (float)aOffsetZ;
+  state.eyeTransform[eye][12] = (float)aOffsetX;
+  state.eyeTransform[eye][13] = (float)aOffsetY;
+  state.eyeTransform[eye][14] = (float)aOffsetZ;
 }
 
 bool VRMockDisplay::CapPosition() const {

--- a/dom/vr/XRView.cpp
+++ b/dom/vr/XRView.cpp
@@ -36,8 +36,7 @@ NS_IMPL_CYCLE_COLLECTION_UNROOT_NATIVE(XRView, Release)
 XRView::XRView(nsISupports* aParent, const XREye& aEye)
     : mParent(aParent),
       mEye(aEye),
-      mPosition(gfx::PointDouble3D()),
-      mOrientation(gfx::QuaternionDouble()),
+      mEyeTransform(gfx::Matrix4x4Double()),
       mJSProjectionMatrix(nullptr) {
   mozilla::HoldJSObjects(this);
 }
@@ -49,14 +48,12 @@ JSObject* XRView::WrapObject(JSContext* aCx,
   return XRView_Binding::Wrap(aCx, this, aGivenProto);
 }
 
-void XRView::Update(const gfx::PointDouble3D& aPosition,
-                    const gfx::QuaternionDouble& aOrientation,
+void XRView::Update(const gfx::Matrix4x4Double& aEyeTransform,
                     const gfx::Matrix4x4& aProjectionMatrix) {
-  mPosition = aPosition;
-  mOrientation = aOrientation;
+  mEyeTransform = aEyeTransform;
   mProjectionMatrix = aProjectionMatrix;
   if (mTransform) {
-    mTransform->Update(aPosition, aOrientation);
+    mTransform->Update(mEyeTransform);
   }
   if (aProjectionMatrix != mProjectionMatrix) {
     mProjectionNeedsUpdate = true;
@@ -87,7 +84,7 @@ void XRView::GetProjectionMatrix(JSContext* aCx,
 
 already_AddRefed<XRRigidTransform> XRView::GetTransform(ErrorResult& aRv) {
   if (!mTransform) {
-    mTransform = new XRRigidTransform(mParent, mPosition, mOrientation);
+    mTransform = new XRRigidTransform(mParent, mEyeTransform);
   }
   RefPtr<XRRigidTransform> transform = mTransform;
   return transform.forget();

--- a/dom/vr/XRView.h
+++ b/dom/vr/XRView.h
@@ -25,8 +25,7 @@ class XRView final : public nsWrapperCache {
 
   explicit XRView(nsISupports* aParent, const XREye& aEye);
 
-  void Update(const gfx::PointDouble3D& aPosition,
-              const gfx::QuaternionDouble& aOrientation,
+  void Update(const gfx::Matrix4x4Double& aEyeTransform,
               const gfx::Matrix4x4& aProjectionMatrix);
   // WebIDL Boilerplate
   nsISupports* GetParentObject() const { return mParent; }
@@ -44,8 +43,7 @@ class XRView final : public nsWrapperCache {
 
   nsCOMPtr<nsISupports> mParent;
   XREye mEye;
-  gfx::PointDouble3D mPosition;
-  gfx::QuaternionDouble mOrientation;
+  gfx::Matrix4x4Double mEyeTransform;
   gfx::Matrix4x4 mProjectionMatrix;
   JS::Heap<JSObject*> mJSProjectionMatrix;
   bool mProjectionNeedsUpdate = true;

--- a/gfx/vr/external_api/moz_external_vr.h
+++ b/gfx/vr/external_api/moz_external_vr.h
@@ -48,7 +48,7 @@ namespace gfx {
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
 #define SHMEM_VERSION "0.0.11"
-static const int32_t kVRExternalVersion = 18;
+static const int32_t kVRExternalVersion = 19;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -344,7 +344,7 @@ struct VRDisplayState {
   VRDisplayCapabilityFlags capabilityFlags;
   VRDisplayBlendMode blendMode;
   VRFieldOfView eyeFOV[VRDisplayState::NumEyes];
-  Point3D_POD eyeTranslation[VRDisplayState::NumEyes];
+  float eyeTransform[VRDisplayState::NumEyes][16];
   IntSize_POD eyeResolution;
   float nativeFramebufferScaleFactor;
   bool suppressFrames;

--- a/gfx/vr/gfxVR.cpp
+++ b/gfx/vr/gfxVR.cpp
@@ -72,9 +72,17 @@ const IntSize VRDisplayInfo::SuggestedEyeResolution() const {
 }
 
 const Point3D VRDisplayInfo::GetEyeTranslation(uint32_t whichEye) const {
-  return Point3D(mDisplayState.eyeTranslation[whichEye].x,
-                 mDisplayState.eyeTranslation[whichEye].y,
-                 mDisplayState.eyeTranslation[whichEye].z);
+  return Point3D(mDisplayState.eyeTransform[whichEye][12],
+                 mDisplayState.eyeTransform[whichEye][13],
+                 mDisplayState.eyeTransform[whichEye][14]);
+}
+
+const Matrix4x4Double VRDisplayInfo::GetEyeTransform(uint32_t whichEye) const {
+  Matrix4x4Double m;
+  for (int i = 0; i < 16; ++i) {
+    m.components[i] = static_cast<double>(mDisplayState.eyeTransform[whichEye][i]);
+  }
+  return m;
 }
 
 const Size VRDisplayInfo::GetStageSize() const {

--- a/gfx/vr/gfxVR.h
+++ b/gfx/vr/gfxVR.h
@@ -65,6 +65,7 @@ struct VRDisplayInfo {
 
   const IntSize SuggestedEyeResolution() const;
   const Point3D GetEyeTranslation(uint32_t whichEye) const;
+  const Matrix4x4Double GetEyeTransform(uint32_t whichEye) const;
   const VRFieldOfView& GetEyeFOV(uint32_t whichEye) const {
     return mDisplayState.eyeFOV[whichEye];
   }


### PR DESCRIPTION
- HVR devices include some rotation in eyeTransform that is not processed right now it WebXR
- It should help to fix: https://github.com/Igalia/wolvic/issues/43