### PR TITLE
Import missing macro std::arch::is_aarch64_feature_detected

### DIFF
--- a/gfx/qcms/src/transform.rs
+++ b/gfx/qcms/src/transform.rs
@@ -56,6 +56,8 @@ use crate::{
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use std::arch::is_aarch64_feature_detected;
+
 pub const PRECACHE_OUTPUT_SIZE: usize = 8192;
 pub const PRECACHE_OUTPUT_MAX: usize = PRECACHE_OUTPUT_SIZE - 1;
 pub const FLOATSCALE: f32 = PRECACHE_OUTPUT_SIZE as f32;


### PR DESCRIPTION
This fixes build of qcms due to missing std::arch::is_aarch64_feature_detected, required to detect neon support.