### PR TITLE
Set event listener to current media control after switching process

### DIFF
--- a/mobile/android/chrome/geckoview/geckoview.js
+++ b/mobile/android/chrome/geckoview/geckoview.js
@@ -382,6 +382,9 @@ class ModuleInfo {
    * Called before the browser is removed
    */
   onDestroyBrowser() {
+    if (this._impl) {
+      this._impl.onDestroyBrowser();
+    }
     this._contentModuleLoaded = false;
   }
 

--- a/mobile/android/modules/geckoview/GeckoViewMediaControl.jsm
+++ b/mobile/android/modules/geckoview/GeckoViewMediaControl.jsm
@@ -15,12 +15,8 @@ class GeckoViewMediaControl extends GeckoViewModule {
     debug`onInit`;
   }
 
-  onEnable() {
-    debug`onEnable`;
-
-    if (this.controller.isActive) {
-      this.handleActivated();
-    }
+  onInitBrowser() {
+    debug`onInitBrowser`;
 
     const options = {
       mozSystemGroup: true,
@@ -33,6 +29,25 @@ class GeckoViewMediaControl extends GeckoViewModule {
     this.controller.addEventListener("positionstatechange", this, options);
     this.controller.addEventListener("metadatachange", this, options);
     this.controller.addEventListener("playbackstatechange", this, options);
+  }
+
+  onDestroyBrowser() {
+    debug`onDestroyBrowser`;
+
+    this.controller.removeEventListener("activated", this);
+    this.controller.removeEventListener("deactivated", this);
+    this.controller.removeEventListener("supportedkeyschange", this);
+    this.controller.removeEventListener("positionstatechange", this);
+    this.controller.removeEventListener("metadatachange", this);
+    this.controller.removeEventListener("playbackstatechange", this);
+  }
+
+  onEnable() {
+    debug`onEnable`;
+
+    if (this.controller.isActive) {
+      this.handleActivated();
+    }
 
     this.registerListener([
       "GeckoView:MediaSession:Play",
@@ -50,13 +65,6 @@ class GeckoViewMediaControl extends GeckoViewModule {
 
   onDisable() {
     debug`onDisable`;
-
-    this.controller.removeEventListener("activated", this);
-    this.controller.removeEventListener("deactivated", this);
-    this.controller.removeEventListener("supportedkeyschange", this);
-    this.controller.removeEventListener("positionstatechange", this);
-    this.controller.removeEventListener("metadatachange", this);
-    this.controller.removeEventListener("playbackstatechange", this);
 
     this.unregisterListener();
   }

--- a/mobile/android/modules/geckoview/GeckoViewModule.jsm
+++ b/mobile/android/modules/geckoview/GeckoViewModule.jsm
@@ -66,6 +66,9 @@ class GeckoViewModule {
   // Override to initialize the browser before it is bound to the window.
   onInitBrowser() {}
 
+  // Override to cleanup when the browser is destroyed.
+  onDestroyBrowser() {}
+
   // Override to initialize module.
   onInit() {}
 


### PR DESCRIPTION
Backport of the upstream fix for bug 1827583, fixing media events in Youtube:

    "youtube.com - Media playback not detected, breaking media notifications,
    media controls, fullscreen landscape, background playback and PiP."
    https://bugzilla.mozilla.org/show_bug.cgi?id=1827583

According to the upstream description of the patch:

    This issue is a timing issue of loading content via about:config etc.

    Although `GeckoViewMediaControl` registers event listeners for
    `MediaController` when enabling `MediaSessionDelegate`, if process
    switching occurs, `browsingContenxt` and `MediaController` are re-created.

    It means that we has to register newer `MediaController`.

    To detect destroying current browser, I will add `onDestroyBrowser` to
    `GeckoViewModule` again (This was removed by bug 1672262).

    https://github.com/mozilla/gecko-dev/commit/7af39f7f34529c9ceea2e4ed48d2426dd0b0ba01

Fixes https://github.com/Igalia/wolvic/pull/643